### PR TITLE
Исключение отдельных файлов js из конечной сборки

### DIFF
--- a/tars/watchers/sprite/symbols.js
+++ b/tars/watchers/sprite/symbols.js
@@ -16,27 +16,13 @@ module.exports = () => {
         ).on('all', (event, watchedPath) => {
             tars.helpers.watcherLog(event, watchedPath);
 
-            switch (tars.config.svg.symbolsConfig.loadingType) {
-                case 'separate-file':
-                case 'separate-file-with-link':
-                    runSequence(
-                        'images:minify-svg',
-                        'images:make-symbols-sprite',
-                        'html:concat-modules-data',
-                        () => {}
-                    );
-                    break;
-                case 'inject':
-                default:
-                    runSequence(
-                        'images:minify-svg',
-                        'images:make-symbols-sprite',
-                        'html:concat-modules-data',
-                        'html:compile-templates',
-                        () => {}
-                    );
-                    break;
-            }
+            runSequence(
+                'images:minify-svg',
+                'images:make-symbols-sprite',
+                'html:concat-modules-data',
+                'html:compile-templates',
+                () => {}
+            );
         });
     }
 


### PR DESCRIPTION
В переиспользуемых модулях есть файлы примеры кода, которые хотелось бы исключить из сборки. Например, _template.js.