### PR TITLE
Исключение из сборки файлов js

### DIFF
--- a/tars/tasks/js/processing.js
+++ b/tars/tasks/js/processing.js
@@ -19,6 +19,7 @@ const generateSourceMaps = tars.config.sourcemaps.js.active && tars.isDevMode;
 const sourceMapsDest = tars.config.sourcemaps.js.inline ? '' : '.';
 const jsPaths = [].concat.apply([], [
     '!./markup/modules/**/data/data.js',
+    '!./markup/modules/**/_*.js',
     './markup/' + staticFolderName + '/js/framework/**/*.js',
     './markup/' + staticFolderName + '/js/libraries/**/*.js',
     './markup/' + staticFolderName + '/js/plugins/**/*.js',


### PR DESCRIPTION
Возможность исключить из сборки в modules отдельные файлы js путем добавления "_" в начале файла. Например, _template.js.