### PR TITLE
Исправил таск pages-and-data-files-processing для корректной работы в Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tars",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "engines": {
     "npm": "^3.x.x",
     "node": "^4.x.x"

--- a/tars/tasks/html/helpers/pages-and-data-files-processing.js
+++ b/tars/tasks/html/helpers/pages-and-data-files-processing.js
@@ -24,7 +24,7 @@ module.exports = function pagesAndDataFilesProcessing() {
     return through2.obj(function (file, enc, callback) {
         const parsedFileRelativePath = path.parse(file.relative);
         const fileName = parsedFileRelativePath.base;
-        const pathParts = parsedFileRelativePath.dir.split('/');
+        const pathParts = parsedFileRelativePath.dir.split(path.sep);
         let fileContent = file.contents.toString();
         let namePrefix = '';
 


### PR DESCRIPTION
В этом таске использовалась unix версия пути к data.js, т.е. через /. В Windows же используется \ для разделения пути, поэтому таск на винде не отрабатывал правильно.