### PR TITLE
Added webpack ProvidePlugin support

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -4,6 +4,10 @@ English description | <a href="../ru/changelog.md">Описание на рус�
 
 # Changelog
 
+## Version 1.9.7
+
+* Added webpack [ProvidePlugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin) support. This is optional, see [tars-config](https://github.com/tars/tars/blob/master/docs/en/options.md#providePlugin).
+
 ## Version 1.9.4
 
 * Build won't be deleted in dev-mode.

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -6,7 +6,7 @@ English description | <a href="../ru/changelog.md">Описание на рус�
 
 ## Version 1.9.7
 
-* Added webpack [ProvidePlugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin) support. This is optional, see [tars-config](https://github.com/tars/tars/blob/master/docs/en/options.md#providePlugin).
+* Added webpack [ProvidePlugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin) support. This is optional, see [tars-config](https://github.com/tars/tars/blob/master/docs/en/options.md#provideplugin).
 
 ## Version 1.9.4
 

--- a/docs/en/options.md
+++ b/docs/en/options.md
@@ -168,6 +168,14 @@ Default: `false`
 
 Switch on/off [Hot module replacement](https://webpack.github.io/docs/hot-module-replacement.html).
 
+##### providePlugin
+
+Type: `Object`
+
+Default: `{}`
+
+[Provide Plugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin) options. Automatically loaded modules.
+
 #### removeConsoleLog
 
 Type: `Boolean`

--- a/docs/ru/changelog.md
+++ b/docs/ru/changelog.md
@@ -6,7 +6,7 @@
 
 ## Version 1.9.7
 
-* Добавлена поддержка [ProvidePlugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin) у webpack. Настройка происходит в [конфиге](https://github.com/tars/tars/blob/master/docs/ru/options.md#providePlugin).
+* Добавлена поддержка [ProvidePlugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin) у webpack. Настройка происходит в [конфиге](https://github.com/tars/tars/blob/master/docs/ru/options.md#provideplugin).
 
 ## Version 1.9.4
 

--- a/docs/ru/changelog.md
+++ b/docs/ru/changelog.md
@@ -4,6 +4,10 @@
 
 # Changelog
 
+## Version 1.9.7
+
+* Добавлена поддержка [ProvidePlugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin) у webpack. Настройка происходит в [конфиге](https://github.com/tars/tars/blob/master/docs/ru/options.md#providePlugin).
+
 ## Version 1.9.4
 
 * Папка build не удаляется при запуске TARS в dev-режиме.

--- a/docs/ru/options.md
+++ b/docs/ru/options.md
@@ -172,6 +172,14 @@ Default: `false`
 
 Включение технологии горячей замены компонентов ([Hot module replacement](https://webpack.github.io/docs/hot-module-replacement.html)).
 
+##### providePlugin
+
+Type: `Object`
+
+Default: `{}`
+
+Параметры для [Provide Plugin](https://webpack.github.io/docs/list-of-plugins.html#provideplugin). Автоматически загружаемые модули.
+
 #### removeConsoleLog
 
 Type: `Boolean`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tars",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "engines": {
     "npm": "^3.x.x",
     "node": "^4.x.x"

--- a/tars-config.js
+++ b/tars-config.js
@@ -69,7 +69,16 @@ module.exports = {
 
         // Special config for webpack
         webpack: {
-            useHMR: false
+            useHMR: false,
+
+            /**
+             * Automatically loaded modules.
+             * Module (value) is loaded when the identifier (key) is used as free variable in a module.
+             * The identifier is filled with the exports of the loaded module.
+             * Example: {$: "jquery"} or {React: 'react'}
+             * @type {Object}
+             */
+            providePlugin: {}
         },
 
         /**

--- a/tars.json
+++ b/tars.json
@@ -1,5 +1,5 @@
 {
     "name": "tars",
-    "version": "1.9.6",
+    "version": "1.9.7",
     "description": "Powerfull markup builder"
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,12 @@ if (compressJs) {
     );
 }
 
+if (tars.config.js.webpack.providePlugin) {
+    plugins.push(
+        new webpack.ProvidePlugin(tars.config.js.webpack.providePlugin)
+    )
+}
+
 if (tars.options.watch.isActive && tars.config.js.webpack.useHMR) {
     plugins.push(
         new webpack.HotModuleReplacementPlugin()


### PR DESCRIPTION
Очень полезный фокус при использовании webpack. Многие упускают или просто не знают о нем.
[В чем суть](http://developers-club.com/posts/274385/) - [перевод](https://habrahabr.ru/post/274385/).

Описание в jsdoc взято с официальной [документации webpack](https://webpack.github.io/docs/list-of-plugins.html#provideplugin).