### PR TITLE
fix: generate '.min' files with min flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tars",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "engines": {
     "node": "^6.x.x"
   },

--- a/tars.json
+++ b/tars.json
@@ -1,5 +1,5 @@
 {
     "name": "tars",
-    "version": "1.11.3",
+    "version": "1.11.4",
     "description": "Powerfull markup builder"
 }

--- a/tars/tasks/html/compile-templates.js
+++ b/tars/tasks/html/compile-templates.js
@@ -89,7 +89,7 @@ if (!tars.flags.ie9 && !tars.flags.ie) {
 patterns.push(
     {
         match: '%=min=%',
-        replacement: tars.flags.min || tars.flags.release ? '.min' : ''
+        replacement: tars.flags.min || tars.flags.release || tars.flags.m ? '.min' : ''
     }, {
         match: '%=hash=%',
         replacement: tars.flags.release ? tars.options.build.hash : ''


### PR DESCRIPTION
Обнаружил ошибку, при попытки сборки `build` версии в `html` файлах не дописывается `.min`