### PR TITLE
Can`t identify of `build` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tars",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "engines": {
     "node": "^6.x.x"
   },

--- a/tars.json
+++ b/tars.json
@@ -1,5 +1,5 @@
 {
     "name": "tars",
-    "version": "1.11.6",
+    "version": "1.11.7",
     "description": "Powerfull markup builder"
 }

--- a/tars/tars.js
+++ b/tars/tars.js
@@ -62,7 +62,7 @@ tars.pluginsConfig = require(helpersDirPath + '/plugins-config-processing')();
 tars.flags = gutil.env;
 
 // Dev mode flag
-tars.isDevMode = !tars.flags.release && !tars.flags.min;
+tars.isDevMode = !tars.flags.release && !tars.flags.min && !tars.flags.m;
 tars.useLiveReload = tars.flags.lr || tars.flags.livereload || tars.flags.tunnel;
 
 // Package name


### PR DESCRIPTION
Обнаружил проблемку. Время от времени при попытке сделать билд, пути к файлам стилей, скриптов и картинок прописывались через `dev`. Как оказалось нужный флаг релиза не отлавливается.