### PR TITLE
fix: copy .* files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tars",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "engines": {
     "node": "^6.x.x"
   },

--- a/tars.json
+++ b/tars.json
@@ -1,5 +1,5 @@
 {
     "name": "tars",
-    "version": "1.11.9",
+    "version": "1.11.10",
     "description": "Powerfull markup builder"
 }

--- a/tars/tasks/other/move-misc-files.js
+++ b/tars/tasks/other/move-misc-files.js
@@ -10,7 +10,7 @@ const browserSync = tars.packages.browserSync;
  */
 module.exports = () => {
     return gulp.task('other:move-misc-files', () => {
-        return gulp.src(`./markup/${tars.config.fs.staticFolderName}/misc/**/*.*`)
+        return gulp.src(`./markup/${tars.config.fs.staticFolderName}/misc/**/*`, { dot: true })
             .pipe(plumber({
                 errorHandler(error) {
                     notifier.error('An error occurred while moving misc-files.', error);


### PR DESCRIPTION
Обнаружил проблему, если попытаться скинуть скрытые файлы (например .htaccess), то gulp.src их просто не видит и не может перекинуть соответственно)