### PR TITLE
Добавил возможность очищать папки вне области tars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tars",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "engines": {
     "node": "^6.x.x"
   },

--- a/tars.json
+++ b/tars.json
@@ -1,5 +1,5 @@
 {
     "name": "tars",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "description": "Powerfull markup builder"
 }

--- a/tars/tars.js
+++ b/tars/tars.js
@@ -151,10 +151,10 @@ if (tars.config.svg.active && tars.config.svg.workflow === 'symbols' && (tars.fl
 }
 
 // availability check '/'
-if (tars.config.devPath.slice(-1) !== '/') {
+if (tars.config.devPath.substr(-1) !== '/') {
     tars.config.devPath = tars.config.devPath + '/';
 }
-if (tars.config.buildPath.slice(-1) !== '/') {
+if (tars.config.buildPath.substr(-1) !== '/') {
     tars.config.buildPath = tars.config.buildPath + '/';
 }
 

--- a/tars/tasks/services/clean.js
+++ b/tars/tasks/services/clean.js
@@ -24,7 +24,7 @@ module.exports = () => {
             pathsToDel.push(tars.options.build.path);
         }
 
-        del(pathsToDel).then(() => {
+        del(pathsToDel, {force: true}).then(() => {
             done();
         });
     });


### PR DESCRIPTION
Почему-то в последнем пуле не добавил эту возможность сразу.. 
Если не добавлять ключ **force: true**, то тарс ругается при попытке очистить папку которая находится(допустим) по пути `../../dev/`, т.е. вне области самого тарса.

p.s. ну и сделал проверку по строке)